### PR TITLE
Implemented ShareableArray

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm install
+      - name: Install Jest CLI
+        run: npm i -g jest-cli
+      - name: Run tests
+        run: jest src/**/*.spec.ts

--- a/benchmark/array.html
+++ b/benchmark/array.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>ShareableArray benchmark</title>
+    </head>
+    <body>
+        <script type="module">
+            // In development mode, import directly from the source
+            import {ShareableArray} from "/src/index.ts";
+
+            function generator() {
+                return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+            }
+
+            const generatedStrings = [];
+            const generatedNumbers = [];
+
+            for (let i = 0; i < 2000000; i++) {
+                generatedStrings.push(generator());
+                generatedNumbers.push(Math.random());
+            }
+
+            function benchmarkArray(array, dataset) {
+                let startTime = new Date().getTime();
+                for (const value of dataset) {
+                    array.push(value);
+                }
+                let endTime = new Date().getTime();
+                console.log(`Pushing values took: ${endTime - startTime}ms`);
+
+                startTime = new Date().getTime();
+                for (let i = 0; i < dataset.length; i++) {
+                    array.at(i);
+                }
+                endTime = new Date().getTime();
+                console.log(`Retrieving values took: ${endTime - startTime}ms.`);
+            }
+
+            console.log("Started benchmarking ShareableArray with normal strings...");
+            const array = new ShareableArray();
+            benchmarkArray(array, generatedStrings);
+
+            console.log("Started benchmarking default Array with normal strings...");
+            benchmarkArray([], generatedStrings);
+
+            console.log("Started benchmarking ShareableArray with numbers...");
+            const numbersArray = new ShareableArray();
+            benchmarkArray(numbersArray, generatedNumbers);
+
+            console.log("Started benchmarking default Array with normal strings...");
+            benchmarkArray([], generatedNumbers);
+
+        </script>
+    </body>
+</html>

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -6,7 +6,8 @@
 </head>
 <body>
     <script type="module">
-        import {ShareableMap} from "./../dist/shared-memory-datastructures.js";
+        // In development mode, import directly from the source
+        import {ShareableMap} from "/src/index.ts";
 
         function generator() {
             return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -1,58 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
-    <script type="module">
-        // In development mode, import directly from the source
-        import {ShareableMap} from "/src/index.ts";
+    <head>
+        <meta charset="UTF-8">
+        <title>ShareableMap and ShareableArray Benchmarks</title>
+    </head>
+    <body>
+        <h1>In-Browser Benchmarks</h1>
 
-        function generator() {
-            return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-        }
+        <p>This page provides access to performance benchmarks for:</p>
 
-        const keyValuePairs = [];
+        <ul>
+            <li><a href="map.html">ShareableMap Benchmarks</a></li>
+            <li><a href="array.html">ShareableArray Benchmarks</a></li>
+        </ul>
 
-        for (let i = 0; i < 2000000; i++) {
-            keyValuePairs.push([generator(), generator()]);
-        }
-
-        function benchmarkMap(map) {
-            let startTime = new Date().getTime();
-            for (const [key, value] of keyValuePairs) {
-                map.set(key, value);
-            }
-            let endTime = new Date().getTime();
-            console.log(`Setting values took: ${endTime - startTime}ms`);
-
-            startTime = new Date().getTime();
-            let foundItems = 0;
-            for (const [key, value] of keyValuePairs) {
-                if (map.has(key)) {
-                    foundItems++;
-                }
-            }
-            endTime = new Date().getTime();
-            console.log(`Checking has values took: ${endTime - startTime}ms. Found ${foundItems} items.`);
-
-            startTime = new Date().getTime();
-            for (const [key, value] of keyValuePairs) {
-                map.get(key);
-            }
-            endTime = new Date().getTime();
-            console.log(`Getting values took: ${endTime - startTime}ms`);
-        }
-
-        console.log("Started benchmarking ShareableMap with normal strings...");
-        const map = new ShareableMap(keyValuePairs.length);
-        benchmarkMap(map);
-
-        // console.log(`Read key was called ${map.readKeyCalled} times`)
-
-        console.log("Started benchmarking default Map...");
-        benchmarkMap(new Map());
-    </script>
-</body>
+        <p>Click on the links above to run the respective benchmarks in your browser.</p>
+    </body>
 </html>

--- a/benchmark/map.html
+++ b/benchmark/map.html
@@ -13,15 +13,20 @@
             return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
         }
 
-        const keyValuePairs = [];
+        const keyValueStringPairs = [];
+        const keyValueNumberPairs = [];
 
         for (let i = 0; i < 2000000; i++) {
-            keyValuePairs.push([generator(), generator()]);
+            keyValueStringPairs.push([generator(), generator()]);
         }
 
-        function benchmarkMap(map) {
+        for (let i = 0; i < 2000000; i++) {
+            keyValueNumberPairs.push([Math.random(), Math.random()]);
+        }
+
+        function benchmarkMap(map, dataset) {
             let startTime = new Date().getTime();
-            for (const [key, value] of keyValuePairs) {
+            for (const [key, value] of dataset) {
                 map.set(key, value);
             }
             let endTime = new Date().getTime();
@@ -29,7 +34,7 @@
 
             startTime = new Date().getTime();
             let foundItems = 0;
-            for (const [key, value] of keyValuePairs) {
+            for (const [key, value] of dataset) {
                 if (map.has(key)) {
                     foundItems++;
                 }
@@ -38,7 +43,7 @@
             console.log(`Checking has values took: ${endTime - startTime}ms. Found ${foundItems} items.`);
 
             startTime = new Date().getTime();
-            for (const [key, value] of keyValuePairs) {
+            for (const [key, value] of dataset) {
                 map.get(key);
             }
             endTime = new Date().getTime();
@@ -46,13 +51,18 @@
         }
 
         console.log("Started benchmarking ShareableMap with normal strings...");
-        const map = new ShareableMap(keyValuePairs.length);
-        benchmarkMap(map);
+        const map = new ShareableMap({expectedSize: keyValueStringPairs.length});
+        benchmarkMap(map, keyValueStringPairs);
 
-        // console.log(`Read key was called ${map.readKeyCalled} times`)
+        console.log("Started benchmarking default Map with normal strings...");
+        benchmarkMap(new Map(), keyValueStringPairs);
 
-        console.log("Started benchmarking default Map...");
-        benchmarkMap(new Map());
+        console.log("Started benchmarking ShareableMap with number strings...");
+        const numberMap = new ShareableMap({expectedSize: keyValueNumberPairs.length});
+        benchmarkMap(numberMap, keyValueNumberPairs);
+
+        console.log("Started benchmarking default Map with number strings...");
+        benchmarkMap(new Map(), keyValueNumberPairs);
     </script>
 </body>
 </html>

--- a/benchmark/map.html
+++ b/benchmark/map.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ShareableMap benchmark</title>
+</head>
+<body>
+    <script type="module">
+        // In development mode, import directly from the source
+        import {ShareableMap} from "/src/index.ts";
+
+        function generator() {
+            return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+        }
+
+        const keyValuePairs = [];
+
+        for (let i = 0; i < 2000000; i++) {
+            keyValuePairs.push([generator(), generator()]);
+        }
+
+        function benchmarkMap(map) {
+            let startTime = new Date().getTime();
+            for (const [key, value] of keyValuePairs) {
+                map.set(key, value);
+            }
+            let endTime = new Date().getTime();
+            console.log(`Setting values took: ${endTime - startTime}ms`);
+
+            startTime = new Date().getTime();
+            let foundItems = 0;
+            for (const [key, value] of keyValuePairs) {
+                if (map.has(key)) {
+                    foundItems++;
+                }
+            }
+            endTime = new Date().getTime();
+            console.log(`Checking has values took: ${endTime - startTime}ms. Found ${foundItems} items.`);
+
+            startTime = new Date().getTime();
+            for (const [key, value] of keyValuePairs) {
+                map.get(key);
+            }
+            endTime = new Date().getTime();
+            console.log(`Getting values took: ${endTime - startTime}ms`);
+        }
+
+        console.log("Started benchmarking ShareableMap with normal strings...");
+        const map = new ShareableMap(keyValuePairs.length);
+        benchmarkMap(map);
+
+        // console.log(`Read key was called ${map.readKeyCalled} times`)
+
+        console.log("Started benchmarking default Map...");
+        benchmarkMap(new Map());
+    </script>
+</body>
+</html>

--- a/src/TransferableDataStructure.ts
+++ b/src/TransferableDataStructure.ts
@@ -1,0 +1,27 @@
+export default class TransferableDataStructure {
+    // Default size of the decoder buffer that's always reused (in bytes)
+    private static readonly DECODER_BUFFER_SIZE = 16384;
+
+    // This buffer can be reused to decode the keys of each pair in the map (and avoids us having to reallocate a new
+    // block of memory for each `get` or `set` operation).
+    private decoderBuffer: ArrayBuffer = new ArrayBuffer(TransferableDataStructure.DECODER_BUFFER_SIZE);
+    private currentDecoderBufferSize: number = TransferableDataStructure.DECODER_BUFFER_SIZE;
+
+    protected allocateMemory(byteSize: number): SharedArrayBuffer | ArrayBuffer {
+        try {
+            return new SharedArrayBuffer(byteSize);
+        } catch (err) {
+            throw new Error(`Could not allocate memory. Tried to allocate ${byteSize} bytes.`);
+        }
+    }
+
+    protected getFittingDecoderBuffer(minimumSize: number): ArrayBuffer {
+        if (this.currentDecoderBufferSize < minimumSize) {
+            const nextPowerOfTwo = 2 ** Math.ceil(Math.log2(minimumSize));
+            this.decoderBuffer = new ArrayBuffer(nextPowerOfTwo);
+            this.currentDecoderBufferSize = nextPowerOfTwo;
+        }
+
+        return this.decoderBuffer;
+    }
+}

--- a/src/TransferableDataStructure.ts
+++ b/src/TransferableDataStructure.ts
@@ -1,4 +1,4 @@
-export default class TransferableDataStructure {
+export default abstract class TransferableDataStructure {
     // Default size of the decoder buffer that's always reused (in bytes)
     private static readonly DECODER_BUFFER_SIZE = 16384;
 

--- a/src/TransferableState.ts
+++ b/src/TransferableState.ts
@@ -1,4 +1,5 @@
 export interface TransferableState {
     indexBuffer: SharedArrayBuffer | ArrayBuffer;
     dataBuffer: SharedArrayBuffer | ArrayBuffer;
+    dataType: "map" | "array";
 }

--- a/src/array/ShareableArray.ts
+++ b/src/array/ShareableArray.ts
@@ -1007,7 +1007,7 @@ export class ShareableArray<T> {
                 console.warn("Shared memory is not supported by this browser. Falling back to non-shared memory.");
                 return new ArrayBuffer(byteSize);
             } catch (e) {
-                throw new Error(`Could not allocated memory. Tried to allocate ${byteSize} bytes.`);
+                throw new Error(`Could not allocate memory. Tried to allocate ${byteSize} bytes.`);
             }
         }
     }

--- a/src/array/ShareableArray.ts
+++ b/src/array/ShareableArray.ts
@@ -3,7 +3,7 @@ import {Serializable} from "../encoding";
 import StringEncoder from "../encoding/StringEncoder";
 import NumberEncoder from "../encoding/NumberEncoder";
 import GeneralPurposeEncoder from "../encoding/GeneralPurposeEncoder";
-import {TransferableState} from "../map";
+import {TransferableState} from "../TransferableState";
 
 export class ShareableArray<T> {
     // One UInt32 per object that's stored in this array. This size here is expected to be in bytes (so 4 * initial

--- a/src/array/ShareableArray.ts
+++ b/src/array/ShareableArray.ts
@@ -1,0 +1,93 @@
+export class ShareableArray<T> implements Array<T> {
+    [n: number]: T;
+
+    get length(): number {
+
+    }
+
+    concat(...items: ConcatArray<T>[]): T[];
+    concat(...items: (ConcatArray<T> | T)[]): T[];
+    concat(...items: (ConcatArray<T> | T)[]): T[] {
+        return [];
+    }
+
+    every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
+    every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    every(predicate, thisArg?: any): any {
+    }
+
+    filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
+    filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+    filter(predicate, thisArg?: any): any {
+    }
+
+    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void {
+    }
+
+    indexOf(searchElement: T, fromIndex?: number): number {
+        return 0;
+    }
+
+    join(separator?: string): string {
+        return "";
+    }
+
+    lastIndexOf(searchElement: T, fromIndex?: number): number {
+        return 0;
+    }
+
+    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[] {
+        return [];
+    }
+
+    pop(): T | undefined {
+        return undefined;
+    }
+
+    push(...items: T[]): number {
+        return 0;
+    }
+
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    reduce(callbackfn, initialValue?): any {
+    }
+
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    reduceRight(callbackfn, initialValue?): any {
+    }
+
+    reverse(): T[] {
+        return [];
+    }
+
+    shift(): T | undefined {
+        return undefined;
+    }
+
+    slice(start?: number, end?: number): T[] {
+        return [];
+    }
+
+    some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
+        return false;
+    }
+
+    sort(compareFn?: (a: T, b: T) => number): this {
+        return undefined;
+    }
+
+    splice(start: number, deleteCount?: number): T[];
+    splice(start: number, deleteCount: number, ...items: T[]): T[];
+    splice(start: number, deleteCount?: number, ...items: T[]): T[] {
+        return [];
+    }
+
+    unshift(...items: T[]): number {
+        return 0;
+    }
+
+}

--- a/src/array/ShareableArray.ts
+++ b/src/array/ShareableArray.ts
@@ -1,93 +1,817 @@
-export class ShareableArray<T> implements Array<T> {
-    [n: number]: T;
+import ShareableArrayOptions from "./ShareableArrayOptions";
+import {Serializable} from "../encoding";
+import StringEncoder from "../encoding/StringEncoder";
+import NumberEncoder from "../encoding/NumberEncoder";
+import GeneralPurposeEncoder from "../encoding/GeneralPurposeEncoder";
+import {TransferableState} from "../map";
+
+export class ShareableArray<T> {
+    // One UInt32 per object that's stored in this array. This size here is expected to be in bytes (so 4 * initial
+    // elements size). The index initially supports storage of 256 / 4 = 64 objects.
+    private static readonly DEFAULT_INDEX_SIZE = 256;
+    // Initial size of the data portion of the array. Is also expected to be reported in bytes.
+    private static readonly DEFAULT_DATA_SIZE = 2048;
+
+    // Where do we keep the length of the array?
+    private static readonly INDEX_SIZE_OFFSET = 0;
+    // Where does the next free portion of space start in the data array?
+    private static readonly INDEX_DATA_FREE_START_OFFSET = 4;
+    // Where is the total amount of space used in the data buffer stored?
+    private static readonly INDEX_TOTAL_USED_SPACE_OFFSET = 8;
+    // From what index do we start keeping track of the items in the index?
+    private static readonly INDEX_TABLE_OFFSET = 12;
+    // How many bytes in the data object are reserved for metadata (value length, used encoder ID).
+    private static readonly DATA_OBJECT_OFFSET = 8;
+
+    // Default size of the decoder buffer that's always reused (in bytes)
+    private static readonly DECODER_BUFFER_SIZE = 16384;
+
+    // Since 1 will never be used as an index in the data table array, we can use it to indicate which values
+    // are set to undefined in the array.
+    private static readonly UNDEFINED_VALUE_IDENTIFIER = 1;
+
+    private indexMem!: SharedArrayBuffer | ArrayBuffer;
+    private dataMem!: SharedArrayBuffer | ArrayBuffer;
+
+    private indexView!: DataView;
+    private dataView!: DataView;
+
+    private readonly stringEncoder = new StringEncoder();
+    private readonly numberEncoder = new NumberEncoder();
+    private readonly generalPurposeEncoder = new GeneralPurposeEncoder();
+
+    private serializer: Serializable<T> | undefined;
+    private originalOptions: ShareableArrayOptions<T>;
+
+    // This buffer can be reused to decode the keys of each pair in the map (and avoids us having to reallocate a new
+    // block of memory for each `get` or `set` operation).
+    private decoderBuffer: ArrayBuffer = new ArrayBuffer(ShareableArray.DECODER_BUFFER_SIZE);
+    private currentDecoderBufferSize: number = ShareableArray.DECODER_BUFFER_SIZE;
+
+    private readonly defaultOptions: ShareableArrayOptions<T> = {
+        // Empty for now
+    };
+
+    constructor(
+        options?: ShareableArrayOptions<T>,
+        ...items: T[]
+    ) {
+        this.originalOptions = {...this.defaultOptions, ...options};
+        this.serializer = this.originalOptions?.serializer;
+
+        this.reset();
+
+        if (items) {
+            this.push(...items);
+        }
+    }
+
+    /**
+     * Get the internal buffers that represent this array and that can be transferred without cost between threads.
+     * Use fromState() to rebuild a ShareableArray after the buffers have been transferred.
+     *
+     * @returns An object containing the WebAssembly memory buffers that represent this array
+     */
+    public toTransferableState(): TransferableState {
+        return {
+            indexBuffer: this.indexMem,
+            dataBuffer: this.dataMem,
+            dataType: "array"
+        };
+    }
+
+
+    /**
+     * Creates a new ShareableArray from existing array state. The state should come from another ShareableArray instance
+     * created beforehand. This state can be retrieved using `toState()` on that ShareableArray.
+     *
+     * Note that when the original ShareableArray used a custom serializer, the same type of serializer must also be
+     * provided here.
+     *
+     * @param state Object containing the index and data buffers
+     * @param options Configuration options for the array:
+     *     - serializer: Optional custom serializer for value types
+     * @returns A new ShareableArray instance constructed from the provided state
+     */
+    public static fromTransferableState<T>(
+        {indexBuffer, dataBuffer, dataType}: TransferableState,
+        options?: ShareableArrayOptions<T>
+    ): ShareableArray<T> {
+        if (dataType !== "array") {
+            throw new TypeError("Invalid data type! Trying to revive array from non-array state.");
+        }
+
+        // Define default options
+        const defaultOptions: ShareableArrayOptions<T> = {};
+
+        const array = new ShareableArray<T>({...defaultOptions, ...options});
+        array.setBuffers(indexBuffer, dataBuffer);
+        return array;
+    }
+
+    /**
+     * Set the internal buffers that represent this array and that can be transferred without cost between threads.
+     *
+     * @param indexBuffer Index table buffer that's used to keep track of which values are stored where in the
+     * dataBuffer.
+     * @param dataBuffer Portion of memory in which all the data itself is stored.
+     */
+    protected setBuffers(indexBuffer: SharedArrayBuffer | ArrayBuffer, dataBuffer: SharedArrayBuffer | ArrayBuffer) {
+        this.indexMem = indexBuffer;
+        this.indexView = new DataView(this.indexMem);
+        this.dataMem = dataBuffer;
+        this.dataView = new DataView(this.dataMem);
+    }
 
     get length(): number {
-
+        return this.indexView.getUint32(ShareableArray.INDEX_SIZE_OFFSET);
     }
 
-    concat(...items: ConcatArray<T>[]): T[];
-    concat(...items: (ConcatArray<T> | T)[]): T[];
-    concat(...items: (ConcatArray<T> | T)[]): T[] {
-        return [];
+    concat(items: (T[] | ShareableArray<T>)): ShareableArray<T> {
+        // Copy buffer from this array (such that we don't need to manually copy all the items (and decode / encode them)
+        const copyOfIndex = this.allocateMemory(this.indexMem.byteLength);
+        const copyOfData = this.allocateMemory(this.dataMem.byteLength);
+        new Uint8Array(copyOfIndex).set(new Uint8Array(this.indexMem));
+        new Uint8Array(copyOfData).set(new Uint8Array(this.dataMem));
+
+        // Create a new ShareableArray that contains these buffers
+        const concatenatedArrays = ShareableArray.fromTransferableState(
+            {
+                indexBuffer: copyOfIndex,
+                dataBuffer: copyOfData,
+                dataType: "array"
+            },
+            this.originalOptions
+        );
+
+        // Now, add the items that have been provided to this function to the copied array
+        for (const item of items) {
+            if (Array.isArray(item)) {
+                // If item is array-like (ConcatArray<T>), we need to add each element individually
+                for (let i = 0; i < item.length; i++) {
+                    concatenatedArrays.push(item[i]);
+                }
+            } else {
+                // Otherwise, just add the single item
+                concatenatedArrays.push(item as T);
+            }
+        }
+
+        return concatenatedArrays;
     }
 
-    every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
-    every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
-    every(predicate, thisArg?: any): any {
+    every(predicate: (value: T | undefined, index: number, array: ShareableArray<T>) => unknown, thisArg?: any): boolean {
+        // Bind the predicate function to thisArg if provided
+        const boundPredicate = thisArg !== undefined
+            ? predicate.bind(thisArg)
+            : predicate;
+
+        // Test each element against the predicate
+        for (let i = 0; i < this.length; i++) {
+            const value = this.at(i);
+            // If the predicate returns a falsy value for any element, return false immediately
+            if (!boundPredicate(value, i, this)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
-    filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
-    filter(predicate, thisArg?: any): any {
+    filter(predicate: (value: T | undefined, index: number, array: ShareableArray<T>) => unknown, thisArg?: any): ShareableArray<T> {
+        // Bind the predicate function to thisArg if provided
+        const boundPredicate = thisArg !== undefined
+            ? predicate.bind(thisArg)
+            : predicate;
+
+        const outputArray = new ShareableArray(this.originalOptions);
+
+        for (let i = 0; i < this.length; i++) {
+            const value = this.at(i);
+            if (boundPredicate(value, i, this)) {
+                outputArray.push(value);
+            }
+        }
+
+        return outputArray;
     }
 
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void {
+    forEach(callbackfn: (value: T | undefined, index: number, array: ShareableArray<T>) => void, thisArg?: any): void {
+        // Bind the predicate function to thisArg if provided
+        const boundCallback = thisArg !== undefined
+            ? callbackfn.bind(thisArg)
+            : callbackfn;
+
+        for (let i = 0; i < this.length; i++) {
+            const value = this.at(i);
+            boundCallback(value, i, this);
+        }
     }
 
     indexOf(searchElement: T, fromIndex?: number): number {
-        return 0;
+        if (fromIndex === undefined || fromIndex < -this.length) {
+            fromIndex = 0;
+        }
+
+        if (-this.length <= fromIndex && fromIndex < 0) {
+            fromIndex += this.length;
+        }
+
+        if (fromIndex >= this.length) {
+            return -1;
+        }
+
+        for (let i = fromIndex; i < this.length; i++) {
+            if (this.at(i) === searchElement) {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
-    join(separator?: string): string {
-        return "";
+    join(separator: string = ","): string {
+        let output = "";
+
+        for (let i = 0; i < this.length; i++) {
+            output += String(this.at(i));
+
+            if (i !== this.length - 1) {
+                output += separator;
+            }
+        }
+
+        return output;
     }
 
     lastIndexOf(searchElement: T, fromIndex?: number): number {
-        return 0;
+        if (fromIndex === undefined || fromIndex >= this.length) {
+            fromIndex = this.length - 1;
+        }
+
+        if (-this.length <= fromIndex && fromIndex < 0) {
+            fromIndex += this.length;
+        }
+
+        if (fromIndex < -this.length) {
+            return -1;
+        }
+
+        for (let i = fromIndex; i >= 0; i--) {
+            if (this.at(i) === searchElement) {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[] {
-        return [];
+    map<U>(callbackfn: (value: T, index: number, array: ShareableArray<T>) => U, resultSerializer?: Serializable<U>, thisArg?: any): ShareableArray<U> {
+        // Bind the predicate function to thisArg if provided
+        const boundCallback = thisArg !== undefined
+            ? callbackfn.bind(thisArg)
+            : callbackfn;
+
+        const mappedArray = new ShareableArray<U>({serializer: resultSerializer});
+
+        for (let i = 0; i < this.length; i++) {
+            mappedArray.push(boundCallback(this.at(i)!, i, this));
+        }
+
+        return mappedArray;
     }
 
     pop(): T | undefined {
-        return undefined;
+        if (this.length <= 0) {
+            return undefined;
+        }
+
+        const lastItem = this.at(this.length - 1);
+        this.deleteItem(this.length - 1);
+        return lastItem;
     }
 
-    push(...items: T[]): number {
-        return 0;
+    push(...items: (T | undefined)[]): number {
+        let currentIdx = this.length;
+        for (const item of items) {
+            this.addItem(currentIdx, item);
+            currentIdx++;
+        }
+
+        return this.length;
     }
 
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
-    reduce(callbackfn, initialValue?): any {
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ShareableArray<T>) => T): T;
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ShareableArray<T>) => T, initialValue: T): T;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ShareableArray<T>) => U, initialValue: U): U;
+    reduce(callbackfn: any, initialValue?: any): any {
+        const length = this.length;
+
+        // If array is empty and no initialValue is provided, throw TypeError
+        if (length === 0 && initialValue === undefined) {
+            throw new TypeError('Reduce of empty array with no initial value');
+        }
+
+        let accumulator;
+        let startIndex;
+
+        // If initialValue is provided, use it as the accumulator and start from index 0
+        if (initialValue !== undefined) {
+            accumulator = initialValue;
+            startIndex = 0;
+        } else {
+            // Otherwise, use the first element as the accumulator and start from index 1
+            accumulator = this.at(0);
+            startIndex = 1;
+        }
+
+        // Iterate through the array, applying the callback function
+        for (let i = startIndex; i < length; i++) {
+            // Only call the callback for indexes that exist in the array
+            if (i in this) {
+                accumulator = callbackfn(accumulator, this.at(i), i, this);
+            }
+        }
+
+        return accumulator;
     }
 
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
-    reduceRight(callbackfn, initialValue?): any {
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ShareableArray<T>) => T): T;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ShareableArray<T>) => T, initialValue: T): T;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ShareableArray<T>) => U, initialValue: U): U;
+    reduceRight(callbackfn: any, initialValue?: any): any {
+        const length = this.length;
+
+        // If array is empty and no initialValue is provided, throw TypeError
+        if (length === 0 && initialValue === undefined) {
+            throw new TypeError('Reduce of empty array with no initial value');
+        }
+
+        let accumulator;
+        let startIndex;
+
+        // If initialValue is provided, use it as the accumulator and start from the last element
+        if (initialValue !== undefined) {
+            accumulator = initialValue;
+            startIndex = length - 1;
+        } else {
+            // Otherwise, use the last element as the accumulator and start from the second-to-last element
+            accumulator = this.at(length - 1);
+            startIndex = length - 2;
+        }
+
+        // Iterate through the array from right to left, applying the callback function
+        for (let i = startIndex; i >= 0; i--) {
+            // Only call the callback for indexes that exist in the array
+            if (i in this) {
+                accumulator = callbackfn(accumulator, this.at(i), i, this);
+            }
+        }
+
+        return accumulator;
     }
 
-    reverse(): T[] {
-        return [];
+    reverse(): ShareableArray<T> {
+        const reversed = new ShareableArray(this.originalOptions);
+        for (let i = this.length - 1; i >= 0; i--) {
+            reversed.push(this.at(i)!)
+        }
+        return reversed;
     }
 
     shift(): T | undefined {
-        return undefined;
+        if (this.length <= 0) {
+            return undefined;
+        }
+
+        const removedElement = this.at(0);
+        this.deleteItem(0);
+        return removedElement;
     }
 
-    slice(start?: number, end?: number): T[] {
-        return [];
+    slice(start?: number, end?: number): ShareableArray<T> {
+        const len = this.length;
+        const result = new ShareableArray<T>(this.originalOptions);
+
+        // Handle undefined start (default to 0)
+        let relativeStart = start === undefined ? 0 : start;
+
+        // Handle negative start (count from end)
+        if (relativeStart < 0) {
+            relativeStart = Math.max(len + relativeStart, 0);
+        } else {
+            relativeStart = Math.min(relativeStart, len);
+        }
+
+        // Handle undefined end (default to length)
+        let relativeEnd = end === undefined ? len : end;
+
+        // Handle negative end (count from end)
+        if (relativeEnd < 0) {
+            relativeEnd = Math.max(len + relativeEnd, 0);
+        } else {
+            relativeEnd = Math.min(relativeEnd, len);
+        }
+
+        // Calculate number of elements to extract
+        const numElements = Math.max(relativeEnd - relativeStart, 0);
+
+        // Extract elements into the new array
+        for (let i = 0; i < numElements; i++) {
+            const index = relativeStart + i;
+            result.push(this.at(index)!);
+        }
+
+        return result;
     }
 
-    some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
+    some(predicate: (value: T | undefined, index: number, array: ShareableArray<T>) => unknown, thisArg?: any): boolean {
+        // Bind the predicate function to thisArg if provided
+        const boundPredicate = thisArg !== undefined
+            ? predicate.bind(thisArg)
+            : predicate;
+
+        // Test each element against the predicate
+        for (let i = 0; i < this.length; i++) {
+            const value = this.at(i)!;
+            // If the predicate returns a falsy value for any element, return false immediately
+            if (boundPredicate(value, i, this)) {
+                return true;
+            }
+        }
+
         return false;
     }
 
     sort(compareFn?: (a: T, b: T) => number): this {
-        return undefined;
+        // TODO: improve efficiency of this implementation.
+
+        // Create a temporary array to sort
+        const tempArray: T[] = [...this];
+
+        // Sort the temporary array
+        tempArray.sort(compareFn);
+
+        // Update the original array with the sorted values
+        for (let i = 0; i < tempArray.length; i++) {
+            // Delete the original item and add the sorted item
+            this.deleteItem(i);
+            this.addItem(i, tempArray[i]);
+        }
+
+        return this;
     }
 
-    splice(start: number, deleteCount?: number): T[];
-    splice(start: number, deleteCount: number, ...items: T[]): T[];
-    splice(start: number, deleteCount?: number, ...items: T[]): T[] {
-        return [];
+    // unshift(...items: T[]): number {
+    //     // Add items to the front of the array
+    //
+    //     if (items.length <= 0) {
+    //         return this.length;
+    //     }
+    //
+    //     const [encoder, encoderId] = this.getEncoder(items[0]);
+    //
+    //     const estimatedRequiredSpace = items.reduce((acc, i) => acc + encoder.maximumLength(i), 0);
+    //
+    //     // First encode all of the objects that should be added into a temporary buffer.
+    //     const tempBuffer = new ArrayBuffer(estimatedRequiredSpace);
+    //     let totalExactSpace = 0;
+    //
+    //     // Also keep track of where these items start in the temp buffer (this information is required to reconstruct the index array further down-the-road).
+    //     const startPositionsNewItems = [];
+    //     for (const item of items) {
+    //         startPositionsNewItems.push(totalExactSpace);
+    //         const encoderArray = new Uint8Array(tempBuffer, totalExactSpace + ShareableArray.DATA_OBJECT_OFFSET, encoder.maximumLength(item));
+    //         const exactSpaceForObject = encoder.encode(item, encoderArray);
+    //         totalExactSpace += (ShareableArray.DATA_OBJECT_OFFSET + exactSpaceForObject);
+    //     }
+    //
+    //     // Now that we've got this information, we should move the pre-existing data in the data array to the end of the array.
+    //     // TODO: continue implementation here
+    //
+    //     return 0;
+    // }
+
+    readonly [Symbol.unscopables]: {
+        [K in number | typeof Symbol.iterator | typeof Symbol.unscopables | "length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight" | "find" | "findIndex" | "fill" | "copyWithin" | "entries" | "keys" | "values" | "includes" | "flatMap" | "flat" | "at" | "findLast" | "findLastIndex" | "toReversed" | "toSorted" | "toSpliced" | "with"]?: boolean
+    } = {
+        length: true,
+        toString: true,
+        toLocaleString: true,
+        pop: true,
+        push: true,
+        concat: true,
+        join: true,
+        reverse: true,
+        shift: true,
+        slice: true,
+        sort: true,
+        splice: true,
+        unshift: true,
+        indexOf: true,
+        lastIndexOf: true,
+        every: true,
+        some: true,
+        forEach: true,
+        map: true,
+        filter: true,
+        reduce: true,
+        reduceRight: true,
+        find: true,
+        findIndex: true,
+        fill: true,
+        copyWithin: true,
+        entries: true,
+        keys: true,
+        values: true,
+        includes: true,
+        flatMap: true,
+        flat: true,
+        at: true,
+        findLast: true,
+        findLastIndex: true,
+        toReversed: true,
+        toSorted: true,
+        toSpliced: true,
+        with: true,
+        [Symbol.iterator]: true,
+        [Symbol.unscopables]: true
+    };
+
+    * [Symbol.iterator](): ArrayIterator<T> {
+        for (let currentIdx = 0; currentIdx < this.length; currentIdx++) {
+            yield this.readItem(currentIdx)!;
+        }
     }
 
-    unshift(...items: T[]): number {
-        return 0;
+    at(index: number): T | undefined {
+        return this.readItem(index);
     }
 
+    * entries(): ArrayIterator<[number, T | undefined]> {
+        for (let currentIdx = 0; currentIdx < this.length; currentIdx++) {
+            const value = this.readItem(currentIdx)!;
+            yield [currentIdx, value];
+        }
+    }
+
+    // fill(value: T, start?: number, end?: number): this {
+    // }
+    //
+    // find<S extends T>(predicate: { (value: T, index: number, obj: T[]): boolean }, thisArg?: any): S | undefined;
+    // find(predicate: { (value: T, index: number, obj: T[]): unknown }, thisArg?: any): T | undefined;
+    // find(predicate: { (value: T, index: number, obj: T[]): boolean } | {
+    //     (value: T, index: number, obj: T[]): unknown
+    // }, thisArg?: any): any {
+    // }
+    //
+    // findIndex(predicate: { (value: T, index: number, obj: T[]): unknown }, thisArg?: any): number {
+    //     return 0;
+    // }
+    //
+    // findLast<S extends T>(predicate: { (value: T, index: number, array: T[]): boolean }, thisArg?: any): S | undefined;
+    // findLast(predicate: { (value: T, index: number, array: T[]): unknown }, thisArg?: any): T | undefined;
+    // findLast(predicate: { (value: T, index: number, array: T[]): boolean } | {
+    //     (value: T, index: number, array: T[]): unknown
+    // }, thisArg?: any): any {
+    // }
+    //
+    // findLastIndex(predicate: { (value: T, index: number, array: T[]): unknown }, thisArg?: any): number {
+    //     return 0;
+    // }
+    //
+    // flat<A, D = 1 extends number>(depth?: D): any {
+    // }
+    //
+    // flatMap<U, This = undefined>(callback: {
+    //     (value: T, index: number, array: T[]): (U | readonly U[])
+    // }, thisArg?: This): U[] {
+    //     return undefined;
+    // }
+    //
+    // includes(searchElement: T, fromIndex?: number): boolean {
+    //     return false;
+    // }
+    //
+    // keys(): ArrayIterator<number> {
+    //     return undefined;
+    // }
+    //
+    // toReversed(): T[] {
+    //     return undefined;
+    // }
+    //
+    // toSorted(compareFn?: { (a: T, b: T): number }): T[] {
+    //     return undefined;
+    // }
+    //
+    // toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+    // toSpliced(start: number, deleteCount?: number): T[];
+    // toSpliced(start: number, deleteCount?: number, ...items: T[]): T[] {
+    //     return undefined;
+    // }
+    //
+    // values(): ArrayIterator<T> {
+    //     return undefined;
+    // }
+    //
+    // with(index: number, value: T): T[] {
+    //     return undefined;
+    // }
+
+    /**
+     * At what position in the data-array does the next block of free space start? This position is returned as number
+     * of bytes since the start of the array.
+     */
+    private get freeStart() {
+        // At what position in the data table does the free space start?
+        return this.indexView.getUint32(ShareableArray.INDEX_DATA_FREE_START_OFFSET);
+    }
+
+    private set freeStart(position: number) {
+        this.indexView.setUint32(ShareableArray.INDEX_DATA_FREE_START_OFFSET, position);
+    }
+
+    private getEncoder(value: T): [Serializable<any>, number] {
+        if (this.serializer) {
+            return [this.serializer, 3];
+        } else {
+            if (typeof value === "number") {
+                return [this.numberEncoder, 0];
+            } else if (typeof value === "string") {
+                return [this.stringEncoder, 1];
+            } else {
+                return [this.generalPurposeEncoder, 2];
+            }
+        }
+    }
+
+    private getEncoderById(id: number): Serializable<any> {
+        return ([this.numberEncoder, this.stringEncoder, this.generalPurposeEncoder, this.serializer] as Serializable<any>[])[id];
+    }
+
+    private getFittingDecoderBuffer(minimumSize: number): ArrayBuffer {
+        if (this.currentDecoderBufferSize < minimumSize) {
+            const nextPowerOfTwo = 2 ** Math.ceil(Math.log2(minimumSize));
+            this.decoderBuffer = new ArrayBuffer(nextPowerOfTwo);
+            this.currentDecoderBufferSize = nextPowerOfTwo;
+        }
+
+        return this.decoderBuffer;
+    }
+
+    private addItem(index: number, item: T | undefined) {
+        // Check if we need to allocate more space in the index buffer first.
+        // Items in the index table are always 4 bytes long (int's)
+        if (ShareableArray.INDEX_TABLE_OFFSET + 4 * index >= this.indexMem.byteLength) {
+            this.doubleIndexStorage();
+        }
+
+        if (item === undefined) {
+            // We keep track of undefined values in the array by storing a zero at their position in the index buffer.
+            this.indexView.setUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * index, ShareableArray.UNDEFINED_VALUE_IDENTIFIER);
+        } else {
+            // Then, check if we need to allocate more space in the data buffer
+            const [valueEncoder, valueEncoderId] = this.getEncoder(item);
+
+            const maxValueLength = valueEncoder.maximumLength(item);
+
+            const dataStart = this.indexView.getUint32(ShareableArray.INDEX_DATA_FREE_START_OFFSET);
+            if (dataStart + (maxValueLength + ShareableArray.DATA_OBJECT_OFFSET) >= this.dataMem.byteLength) {
+                this.doubleDataStorage();
+            }
+
+            // Now, encode this value into the data storage
+            const exactValueLength = valueEncoder.encode(
+                item,
+                new Uint8Array(
+                    this.dataMem,
+                    this.freeStart + ShareableArray.DATA_OBJECT_OFFSET,
+                    maxValueLength
+                ),
+            );
+
+            // Keep track of the type of encoder that was used to store the values in the data array
+            this.dataView.setUint32(this.freeStart, valueEncoderId);
+            // Keep track of the exact length in bytes for this value object.
+            this.dataView.setUint32(this.freeStart + 4, exactValueLength);
+
+            // Set pointer in index array to the last position.
+            this.indexView.setUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * index, this.freeStart);
+
+            // Finally, update the pointer to the next block of available space in the data array
+            this.freeStart += exactValueLength + ShareableArray.DATA_OBJECT_OFFSET;
+        }
+
+
+        // Increase the size of the array
+        const previousSize = this.indexView.getUint32(ShareableArray.INDEX_SIZE_OFFSET);
+        this.indexView.setUint32(ShareableArray.INDEX_SIZE_OFFSET, previousSize + 1);
+    }
+
+    private readItem(index: number): T | undefined {
+        const size = this.indexView.getUint32(ShareableArray.INDEX_SIZE_OFFSET);
+        if (index < 0 || index >= size) {
+            return undefined;
+        }
+
+        // Retrieve the position in the data array where this object is stored
+        const dataPos = this.indexView.getUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * index);
+
+        if (dataPos === ShareableArray.UNDEFINED_VALUE_IDENTIFIER) {
+            return undefined;
+        }
+
+        const valueEncoderId = this.dataView.getUint32(dataPos);
+        const valueLength = this.dataView.getUint32(dataPos + 4);
+
+        // Find the correct value encoder and decode the value at the requested position in the data array
+        const encoder = this.getEncoderById(valueEncoderId);
+
+        // Copy from shared memory to a temporary private buffer (since we cannot directly decode from shared memory)
+        const sourceView = new Uint8Array(this.dataView.buffer, dataPos + ShareableArray.DATA_OBJECT_OFFSET, valueLength);
+
+        const targetView = new Uint8Array(this.getFittingDecoderBuffer(valueLength), 0, valueLength);
+        targetView.set(sourceView);
+
+        return encoder.decode(targetView);
+    }
+
+    private deleteItem(index: number): void {
+        const dataPos = this.indexView.getUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * index);
+
+        if (dataPos !== 0) {
+            const valueEncoderId = this.dataView.getUint32(dataPos);
+            const valueLength = this.dataView.getUint32(dataPos + 4);
+
+            // Check if this is the last item in the data space
+            if (index === this.length - 1) {
+                // Simply free this part of memory
+                this.freeStart -= (valueLength + ShareableArray.DATA_OBJECT_OFFSET);
+            } else {
+                // Since the object is situated in the middle of the array, we need to shift all data that's coming
+                // after this object (in both the index and data buffers).
+
+                const dataPointer = this.indexView.getUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * index);
+                const deletedObjectSize = valueLength + ShareableArray.DATA_OBJECT_OFFSET;
+
+                // Move all bytes starting from the next encoded block forward in the data array
+                for (let i = dataPointer + deletedObjectSize; i < this.dataMem.byteLength - 4; i += 4) {
+                    this.dataView.setUint32(i - deletedObjectSize, this.dataView.getUint32(i + 4));
+                }
+
+                for (let i = index + 1; i < this.length - 1; i++) {
+                    // Move the next 4 bytes into the previous 4 bytes of the index array
+                    this.indexView.setUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * (i - 1), this.indexView.getUint32(ShareableArray.INDEX_TABLE_OFFSET + 4 * i));
+                }
+            }
+        }
+
+        const previousSize = this.indexView.getUint32(ShareableArray.INDEX_SIZE_OFFSET);
+        this.indexView.setUint32(ShareableArray.INDEX_SIZE_OFFSET, previousSize - 1);
+    }
+
+    private doubleIndexStorage() {
+        const newIndexMem = this.allocateMemory(this.indexMem.byteLength * 2);
+        const newIndexArray = new Uint8Array(newIndexMem);
+
+        // Copy data from old index to new index
+        newIndexArray.set(new Uint8Array(this.indexMem));
+
+        this.indexMem = newIndexMem;
+        this.indexView = new DataView(this.indexMem);
+    }
+
+    private doubleDataStorage() {
+        const newDataMem = this.allocateMemory(this.dataMem.byteLength * 2);
+        const newDataArray = new Uint8Array(newDataMem);
+
+        // Copy data from old data buffer to new buffer
+        newDataArray.set(new Uint8Array(this.dataMem));
+
+        this.dataMem = newDataMem;
+        this.dataView = new DataView(this.dataMem);
+    }
+
+    private reset() {
+        this.indexMem = this.allocateMemory(ShareableArray.DEFAULT_INDEX_SIZE);
+        this.indexView = new DataView(this.indexMem);
+
+        this.dataMem = this.allocateMemory(ShareableArray.DEFAULT_DATA_SIZE);
+        this.dataView = new DataView(this.dataMem);
+    }
+
+    private allocateMemory(byteSize: number): SharedArrayBuffer | ArrayBuffer {
+        try {
+            return new SharedArrayBuffer(byteSize);
+        } catch (err) {
+            try {
+                // Fallback to non-shared memory
+                console.warn("Shared memory is not supported by this browser. Falling back to non-shared memory.");
+                return new ArrayBuffer(byteSize);
+            } catch (e) {
+                throw new Error(`Could not allocated memory. Tried to allocate ${byteSize} bytes.`);
+            }
+        }
+    }
 }

--- a/src/array/ShareableArrayOptions.ts
+++ b/src/array/ShareableArrayOptions.ts
@@ -1,0 +1,10 @@
+import {Serializable} from "../encoding";
+
+export default interface ShareableArrayOptions<T> {
+    /**
+     * Custom serializer to convert the objects stored in this array as a value to an ArrayBuffer and vice-versa.
+     * Providing your own implementation of a serializable for complex objects can drastically speed up real-world
+     * performance of the ShareableArray.
+     */
+    serializer?: Serializable<T>;
+}

--- a/src/array/__tests__/ShareableArray.spec.ts
+++ b/src/array/__tests__/ShareableArray.spec.ts
@@ -1,0 +1,40 @@
+import {ShareableArray} from "../ShareableArray";
+
+describe("ShareableArray", () => {
+    const randomItemsAmount = 50000;
+
+    const generatedData: string[] = [];
+
+    for (let i = 0; i < randomItemsAmount; i++) {
+        generatedData.push(generateRandomString());
+    }
+
+    beforeAll(() => {
+        const { TextEncoder, TextDecoder } = require("util");
+        globalThis.TextEncoder = TextEncoder;
+        globalThis.TextDecoder = TextDecoder;
+    });
+
+    it("should correctly add items", () => {
+        const array = new ShareableArray<string>();
+        for (const item of generatedData) {
+            array.push(item);
+        }
+        expect(array.length).toEqual(randomItemsAmount);
+    });
+
+    it("should correctly return the items that have been added before", () => {
+        const array = new ShareableArray<string>();
+        for (const item of generatedData) {
+            array.push(item);
+        }
+
+        for (let idx = 0; idx < randomItemsAmount; idx++) {
+            expect(array.at(idx)).toEqual(generatedData[idx]);
+        }
+    });
+});
+
+function generateRandomString() {
+    return Math.random().toString(36).substring(7);
+}

--- a/src/array/__tests__/ShareableArray.spec.ts
+++ b/src/array/__tests__/ShareableArray.spec.ts
@@ -22,6 +22,8 @@ describe("ShareableArray", () => {
         }
         expect(array.length).toEqual(randomItemsAmount);
     });
+    
+    
 
     it("should correctly return the items that have been added before", () => {
         const array = new ShareableArray<string>();
@@ -31,6 +33,115 @@ describe("ShareableArray", () => {
 
         for (let idx = 0; idx < randomItemsAmount; idx++) {
             expect(array.at(idx)).toEqual(generatedData[idx]);
+        }
+    });
+
+    it("should correctly store and retrieve simple objects", () => {
+        const array = new ShareableArray<{ id: number, name: string }>();
+        const testObjects = [
+            {id: 1, name: "first"},
+            {id: 2, name: "second"},
+            {id: 3, name: "third"}
+        ];
+
+        testObjects.forEach(obj => array.push(obj));
+
+        for (let i = 0; i < testObjects.length; i++) {
+            expect(array.at(i)).toEqual(testObjects[i]);
+        }
+    });
+
+    it("should correctly store and retrieve nested objects", () => {
+        const array = new ShareableArray<{ user: { id: number, details: { name: string } } }>();
+        const testObjects = [
+            {user: {id: 1, details: {name: "John"}}},
+            {user: {id: 2, details: {name: "Jane"}}}
+        ];
+
+        testObjects.forEach(obj => array.push(obj));
+
+        for (let i = 0; i < testObjects.length; i++) {
+            expect(array.at(i)).toEqual(testObjects[i]);
+        }
+    });
+
+    it("should correctly store and retrieve objects with array properties", () => {
+        const array = new ShareableArray<{ id: number, tags: string[] }>();
+        const testObjects = [
+            {id: 1, tags: ["tag1", "tag2"]},
+            {id: 2, tags: ["tag3", "tag4", "tag5"]}
+        ];
+
+        testObjects.forEach(obj => array.push(obj));
+
+        for (let i = 0; i < testObjects.length; i++) {
+            expect(array.at(i)).toEqual(testObjects[i]);
+        }
+    });
+
+    it("should correctly store and retrieve complex nested objects", () => {
+        type ComplexObject = {
+            id: number,
+            metadata: {
+                created: string,
+                tags: string[]
+            },
+            data: {
+                user: {
+                    details: {
+                        name: string,
+                        contacts: {
+                            email: string,
+                            phone?: string
+                        }[]
+                    }
+                }
+            }
+        };
+
+        const array = new ShareableArray<ComplexObject>();
+        const testObjects: ComplexObject[] = [
+            {
+                id: 1,
+                metadata: {
+                    created: '2025-01-01',
+                    tags: ["important", "user"]
+                },
+                data: {
+                    user: {
+                        details: {
+                            name: "John Doe",
+                            contacts: [
+                                {email: "john@example.com", phone: "1234567"},
+                                {email: "john.doe@example.com"}
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                id: 2,
+                metadata: {
+                    created: '2025-01-02',
+                    tags: ["regular"]
+                },
+                data: {
+                    user: {
+                        details: {
+                            name: "Jane Doe",
+                            contacts: [
+                                {email: "jane@example.com"}
+                            ]
+                        }
+                    }
+                }
+            }
+        ];
+
+        testObjects.forEach(obj => array.push(obj));
+
+        for (let i = 0; i < testObjects.length; i++) {
+            expect(array.at(i)).toEqual(testObjects[i]);
         }
     });
 
@@ -158,6 +269,310 @@ describe("ShareableArray", () => {
         expect(array.lastIndexOf("grape")).toBe(4);
         expect(array.lastIndexOf("mango")).toBe(-1);
         expect(array.lastIndexOf("banana", 2)).toBe(1);
+    });
+
+    it("should correctly pop elements from a non-empty array", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange"].forEach(item => array.push(item));
+
+        expect(array.pop()).toBe("orange");
+        expect(array.pop()).toBe("banana");
+        expect(array.pop()).toBe("apple");
+    });
+
+    it("should return undefined when popping from an empty array", () => {
+        const array = new ShareableArray<string>();
+        expect(array.pop()).toBeUndefined();
+    });
+
+    it("should correctly update length after pop operations", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange"].forEach(item => array.push(item));
+
+        expect(array.length).toBe(3);
+        array.pop();
+        expect(array.length).toBe(2);
+        array.pop();
+        expect(array.length).toBe(1);
+        array.pop();
+        expect(array.length).toBe(0);
+    });
+
+    it("should correctly reduce array of numbers", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const sum = array.reduce((acc, curr) => acc! + curr!, 0);
+        expect(sum).toBe(15);
+
+        const emptyArray = new ShareableArray<number>();
+        expect(emptyArray.reduce((acc, curr) => acc! + curr!, 0)).toBe(0);
+    });
+
+    it("should correctly reduce array of strings", () => {
+        const array = new ShareableArray<string>();
+        ["Hello", " ", "World", "!"].forEach(s => array.push(s));
+
+        const concatenated = array.reduce((acc, curr) => acc! + curr!);
+        expect(concatenated).toBe("Hello World!");
+
+        const emptyArray = new ShareableArray<string>();
+        expect(() => emptyArray.reduce((acc, curr) => acc! + curr!)).toThrow();
+    });
+
+    it("should correctly reduce with initial value", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3].forEach(n => array.push(n));
+
+        const sumPlusTen = array.reduce((acc, curr) => acc + curr!, 10);
+        expect(sumPlusTen).toBe(16);
+
+        const emptyArray = new ShareableArray<number>();
+        expect(emptyArray.reduce((acc, curr) => acc + curr!, 10)).toBe(10);
+    });
+
+    it("should correctly reduce right array of numbers", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const result = array.reduceRight((acc, curr) => acc! - curr!);
+        expect(result).toBe(-5);
+
+        const emptyArray = new ShareableArray<number>();
+        expect(() => emptyArray.reduceRight((acc, curr) => acc! - curr!)).toThrow();
+    });
+
+    it("should correctly reduce right with initial value", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3].forEach(n => array.push(n));
+
+        const result = array.reduceRight((acc, curr) => acc - curr!, 10);
+        expect(result).toBe(4);
+
+        const emptyArray = new ShareableArray<number>();
+        expect(emptyArray.reduceRight((acc, curr) => acc - curr!, 10)).toBe(10);
+    });
+
+    it("should correctly reverse non-empty array", () => {
+        const array = new ShareableArray<string>();
+        ["a", "b", "c", "d"].forEach(item => array.push(item));
+
+        array.reverse();
+
+        expect([...array]).toEqual(["d", "c", "b", "a"]);
+    });
+
+    it("should handle reverse on empty array", () => {
+        const array = new ShareableArray<string>();
+        array.reverse();
+        expect(array.length).toBe(0);
+    });
+
+    it("should correctly shift elements from non-empty array", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange"].forEach(item => array.push(item));
+
+        expect(array.shift()).toBe("apple");
+        expect(array.shift()).toBe("banana");
+        expect(array.shift()).toBe("orange");
+    });
+
+    it("should return undefined when shifting from empty array", () => {
+        const array = new ShareableArray<string>();
+        expect(array.shift()).toBeUndefined();
+    });
+
+    it("should correctly update length after shift operations", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange"].forEach(item => array.push(item));
+
+        expect(array.length).toBe(3);
+        array.shift();
+        expect(array.length).toBe(2);
+        array.shift();
+        expect(array.length).toBe(1);
+        array.shift();
+        expect(array.length).toBe(0);
+    });
+
+    it("should correctly fill array with a number value", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+        array.fill(0);
+        expect([...array]).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    it("should correctly fill array with a string value", () => {
+        const array = new ShareableArray<string>();
+        ["a", "b", "c"].forEach(s => array.push(s));
+        array.fill("x");
+        expect([...array]).toEqual(["x", "x", "x"]);
+    });
+
+    it("should correctly fill array with an object value", () => {
+        const array = new ShareableArray<object>();
+        [{id: 1}, {id: 2}, {id: 3}].forEach(obj => array.push(obj));
+        const fillObj = {test: true};
+        array.fill(fillObj);
+        expect([...array]).toEqual([fillObj, fillObj, fillObj]);
+    });
+
+    it("should correctly fill array with start and end indexes", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+        array.fill(0, 1, 4);
+        expect([...array]).toEqual([1, 0, 0, 0, 5]);
+    });
+
+    it("should handle filling empty array", () => {
+        const array = new ShareableArray<number>();
+        array.fill(1);
+        expect([...array]).toEqual([]);
+    });
+
+    it("should handle negative indexes when filling", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+        array.fill(0, -3, -1);
+        expect([...array]).toEqual([1, 2, 0, 0, 5]);
+    });
+
+    it("should handle out of bounds indexes when filling", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3].forEach(n => array.push(n));
+        array.fill(0, -5, 10);
+        expect([...array]).toEqual([0, 0, 0]);
+    });
+
+    it("should correctly find element using find()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const found = array.find(num => num! > 3);
+        expect(found).toBe(4);
+
+        const evenNumber = array.find(num => num! % 2 === 0);
+        expect(evenNumber).toBe(2);
+    });
+
+    it("should return undefined when no element is found using find()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const notFound = array.find(num => num! > 10);
+        expect(notFound).toBeUndefined();
+    });
+
+    it("should correctly find element index using findIndex()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const foundIndex = array.findIndex(num => num! > 3);
+        expect(foundIndex).toBe(3);
+
+        const evenNumberIndex = array.findIndex(num => num! % 2 === 0);
+        expect(evenNumberIndex).toBe(1);
+    });
+
+    it("should return -1 when no element index is found using findIndex()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const notFoundIndex = array.findIndex(num => num! > 10);
+        expect(notFoundIndex).toBe(-1);
+    });
+
+    it("should correctly find last element using findLast()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5, 2, 4].forEach(n => array.push(n));
+
+        const found = array.findLast(num => num! > 3);
+        expect(found).toBe(4);
+
+        const evenNumber = array.findLast(num => num! % 2 === 0);
+        expect(evenNumber).toBe(4);
+    });
+
+    it("should return undefined when no element is found using findLast()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const notFound = array.findLast(num => num! > 10);
+        expect(notFound).toBeUndefined();
+    });
+
+    it("should correctly find last element index using findLastIndex()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5, 2, 4].forEach(n => array.push(n));
+
+        const foundIndex = array.findLastIndex(num => num! > 3);
+        expect(foundIndex).toBe(6);
+
+        const evenNumberIndex = array.findLastIndex(num => num! % 2 === 0);
+        expect(evenNumberIndex).toBe(6);
+    });
+
+    it("should return -1 when no element index is found using findLastIndex()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const notFoundIndex = array.findLastIndex(num => num! > 10);
+        expect(notFoundIndex).toBe(-1);
+    });
+
+
+    it("should correctly check if element exists using includes()", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange"].forEach(item => array.push(item));
+
+        expect(array.includes("banana")).toBeTruthy();
+        expect(array.includes("grape")).toBeFalsy();
+        // `fromIndex >= array.length` => The array should not be searched.
+        expect(array.includes("banana", 2)).toBeFalsy();
+        // Start searching after "apple" (which should thus not be found).
+        expect(array.includes("apple", 1)).toBeFalsy();
+    });
+
+    it("should correctly return iterator for array keys()", () => {
+        const array = new ShareableArray<string>();
+        ["a", "b", "c"].forEach(item => array.push(item));
+
+        const keys = [...array.keys()];
+        expect(keys).toEqual([0, 1, 2]);
+    });
+
+    it("should correctly flatMap array elements", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3].forEach(n => array.push(n));
+
+        const result = array.flatMap(x => [x!, x! * 2]);
+        expect([...result]).toEqual([1, 2, 2, 4, 3, 6]);
+        expect(result).toBeInstanceOf(ShareableArray);
+    });
+
+    it("should correctly reverse array without modifying original using toReversed()", () => {
+        const array = new ShareableArray<string>();
+        ["a", "b", "c", "d"].forEach(item => array.push(item));
+
+        const reversed = array.toReversed();
+
+        expect([...reversed]).toEqual(["d", "c", "b", "a"]);
+        expect([...array]).toEqual(["a", "b", "c", "d"]);
+        expect(reversed).toBeInstanceOf(ShareableArray);
+    });
+
+    it("should correctly sort array without modifying original using toSorted()", () => {
+        const array = new ShareableArray<number>();
+        [3, 1, 4, 1, 5, 9, 2, 6].forEach(n => array.push(n));
+
+        const sorted = array.toSorted();
+        const customSorted = array.toSorted((a, b) => b! - a!);
+
+        expect([...sorted]).toEqual([1, 1, 2, 3, 4, 5, 6, 9]);
+        expect([...customSorted]).toEqual([9, 6, 5, 4, 3, 2, 1, 1]);
+        expect([...array]).toEqual([3, 1, 4, 1, 5, 9, 2, 6]);
+        expect(sorted).toBeInstanceOf(ShareableArray);
+        expect(customSorted).toBeInstanceOf(ShareableArray);
     });
 });
 

--- a/src/array/__tests__/ShareableArray.spec.ts
+++ b/src/array/__tests__/ShareableArray.spec.ts
@@ -520,6 +520,64 @@ describe("ShareableArray", () => {
         expect(notFoundIndex).toBe(-1);
     });
 
+    it("should correctly unshift elements to an empty array", () => {
+        const array = new ShareableArray<string>();
+        array.unshift("first");
+        expect(array.length).toBe(1);
+        expect(array.at(0)).toBe("first");
+    });
+
+    it("should correctly unshift multiple elements in sequence", () => {
+        const array = new ShareableArray<string>();
+        array.unshift("third");
+        array.unshift("second");
+        array.unshift("first");
+
+        console.log(array.toString());
+
+        expect(array.length).toBe(3);
+        expect([...array]).toEqual(["first", "second", "third"]);
+    });
+
+    it("should correctly unshift different data types", () => {
+        const array = new ShareableArray<any>();
+        array.unshift(42);
+        array.unshift("test");
+        array.unshift({key: "value"});
+        array.unshift([1, 2, 3]);
+
+        expect(array.length).toBe(4);
+        expect(array.at(0)).toEqual([1, 2, 3]);
+        expect(array.at(1)).toEqual({key: "value"});
+        expect(array.at(2)).toBe("test");
+        expect(array.at(3)).toBe(42);
+    });
+
+    it("should correctly update length after unshift operations", () => {
+        const array = new ShareableArray<number>();
+        expect(array.length).toBe(0);
+
+        array.unshift(1);
+        expect(array.length).toBe(1);
+
+        array.unshift(2);
+        expect(array.length).toBe(2);
+
+        array.unshift(3);
+        expect(array.length).toBe(3);
+    });
+
+    it("should correctly handle multiple items in a single unshift operation", () => {
+        const array = new ShareableArray<number>();
+        array.unshift(1, 2, 3, 4);
+
+        expect(array.length).toBe(4);
+        expect([...array]).toEqual([1, 2, 3, 4]);
+
+        array.unshift(5, 6);
+        expect(array.length).toBe(6);
+        expect([...array]).toEqual([5, 6, 1, 2, 3, 4]);
+    });
 
     it("should correctly check if element exists using includes()", () => {
         const array = new ShareableArray<string>();
@@ -574,6 +632,8 @@ describe("ShareableArray", () => {
         expect(sorted).toBeInstanceOf(ShareableArray);
         expect(customSorted).toBeInstanceOf(ShareableArray);
     });
+    
+    
 });
 
 function generateRandomString() {

--- a/src/array/__tests__/ShareableArray.spec.ts
+++ b/src/array/__tests__/ShareableArray.spec.ts
@@ -23,7 +23,6 @@ describe("ShareableArray", () => {
         expect(array.length).toEqual(randomItemsAmount);
     });
     
-    
 
     it("should correctly return the items that have been added before", () => {
         const array = new ShareableArray<string>();
@@ -532,8 +531,6 @@ describe("ShareableArray", () => {
         array.unshift("third");
         array.unshift("second");
         array.unshift("first");
-
-        console.log(array.toString());
 
         expect(array.length).toBe(3);
         expect([...array]).toEqual(["first", "second", "third"]);

--- a/src/array/__tests__/ShareableArray.spec.ts
+++ b/src/array/__tests__/ShareableArray.spec.ts
@@ -33,6 +33,132 @@ describe("ShareableArray", () => {
             expect(array.at(idx)).toEqual(generatedData[idx]);
         }
     });
+
+    it("should correctly concatenate two ShareableArrays", () => {
+        const arrA = new ShareableArray<string>();
+        const arrB = new ShareableArray<string>();
+
+        const dummyData = ["a", "b", "c", "d", "e", "1", "2", "3", "4", "5"];
+
+        // Fill the first array
+        for (const item of dummyData.slice(0, 5)) {
+            arrA.push(item);
+        }
+
+        // Fill the second array
+        for (const item of dummyData.slice(5, 10)) {
+            arrB.push(item);
+        }
+
+        const concatenated = arrA.concat(arrB);
+
+        expect(concatenated.length).toEqual(dummyData.length);
+
+        // Check if all items from the dummy data are present in the concatenated arrays
+        for (const [idx, dummyItem] of dummyData.entries()) {
+            expect(concatenated.at(idx)).toEqual(dummyItem);
+        }
+    });
+
+    it("should correctly concatenate a ShareableArray with a normal array", () => {
+        const arrA = new ShareableArray<string>();
+        const arrB = [];
+
+        const dummyData = ["a", "b", "c", "d", "e", "1", "2", "3", "4", "5"];
+
+        // Fill the first array
+        for (const item of dummyData.slice(0, 5)) {
+            arrA.push(item);
+        }
+
+        // Fill the second array
+        for (const item of dummyData.slice(5, 10)) {
+            arrB.push(item);
+        }
+
+        const concatenated = arrA.concat(arrB);
+
+        expect(concatenated.length).toEqual(dummyData.length);
+
+        // Check if all items from the dummy data are present in the concatenated arrays
+        for (const [idx, dummyItem] of dummyData.entries()) {
+            expect(concatenated.at(idx)).toEqual(dummyItem);
+        }
+    });
+
+    it("should correctly check if all elements satisfy a condition using every()", () => {
+        const array = new ShareableArray<number>();
+        [2, 4, 6, 8, 10].forEach(n => array.push(n));
+
+        expect(array.every(num => num! % 2 === 0)).toBeTruthy();
+        expect(array.every(num => num! > 5)).toBeFalsy();
+    });
+
+    it("should correctly filter elements using filter()", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach(n => array.push(n));
+
+        const filtered = array.filter(num => num! % 2 === 0);
+        expect(filtered.length).toBe(5);
+        expect([...filtered].every(num => num % 2 === 0)).toBeTruthy();
+    });
+
+    it("should correctly execute forEach() on all elements", () => {
+        const array = new ShareableArray<number>();
+        [1, 2, 3, 4, 5].forEach(n => array.push(n));
+
+        const result: number[] = [];
+        array.forEach(num => result.push(num! * 2));
+
+        expect(result).toEqual([2, 4, 6, 8, 10]);
+    });
+
+    it("should correctly find element index using indexOf()", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange", "banana", "grape"].forEach(item => array.push(item));
+
+        expect(array.indexOf("banana")).toBe(1);
+        expect(array.indexOf("grape")).toBe(4);
+        expect(array.indexOf("mango")).toBe(-1);
+        expect(array.indexOf("banana", 2)).toBe(3);
+    });
+
+    it("should correctly join elements with different delimiters", () => {
+        const emptyArray = new ShareableArray<string>();
+        const singleArray = new ShareableArray<string>();
+        const multiArray = new ShareableArray<string>();
+
+        singleArray.push("apple");
+        ["apple", "banana", "orange"].forEach(item => multiArray.push(item));
+
+        // Empty array
+        expect(emptyArray.join()).toBe("");
+        expect(emptyArray.join("|")).toBe("");
+        expect(emptyArray.join(" and ")).toBe("");
+        expect(emptyArray.join("")).toBe("");
+
+        // Single element array
+        expect(singleArray.join()).toBe("apple");
+        expect(singleArray.join("|")).toBe("apple");
+        expect(singleArray.join(" and ")).toBe("apple");
+        expect(singleArray.join("")).toBe("apple");
+
+        // Multiple elements array
+        expect(multiArray.join()).toBe("apple,banana,orange");
+        expect(multiArray.join("|")).toBe("apple|banana|orange");
+        expect(multiArray.join(" and ")).toBe("apple and banana and orange");
+        expect(multiArray.join("")).toBe("applebananaorange");
+    });
+
+    it("should correctly find last element index using lastIndexOf()", () => {
+        const array = new ShareableArray<string>();
+        ["apple", "banana", "orange", "banana", "grape"].forEach(item => array.push(item));
+
+        expect(array.lastIndexOf("banana")).toBe(3);
+        expect(array.lastIndexOf("grape")).toBe(4);
+        expect(array.lastIndexOf("mango")).toBe(-1);
+        expect(array.lastIndexOf("banana", 2)).toBe(1);
+    });
 });
 
 function generateRandomString() {

--- a/src/array/index.ts
+++ b/src/array/index.ts
@@ -1,0 +1,8 @@
+import {ShareableArray} from "./ShareableArray";
+import ShareableArrayOptions from "./ShareableArrayOptions";
+
+export {
+    ShareableArray
+};
+
+export type {ShareableArrayOptions};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./encoding";
 export * from "./map";
+export * from "./TransferableState"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./encoding";
 export * from "./map";
+export * from "./array";
 export * from "./TransferableState"

--- a/src/map/ShareableMap.ts
+++ b/src/map/ShareableMap.ts
@@ -4,7 +4,7 @@ import StringEncoder from "./../encoding/StringEncoder";
 import NumberEncoder from "./../encoding/NumberEncoder";
 import GeneralPurposeEncoder from "./../encoding/GeneralPurposeEncoder";
 import ShareableMapOptions from "./ShareableMapOptions";
-import {TransferableState} from "./TransferableState";
+import {TransferableState} from "../TransferableState";
 
 export class ShareableMap<K, V> {
     // The default load factor to which this map should adhere

--- a/src/map/ShareableMap.ts
+++ b/src/map/ShareableMap.ts
@@ -583,9 +583,10 @@ export class ShareableMap<K, V> {
             }
         }
 
-        for (let i = 0; i < this.dataView.byteLength; i += 4) {
-            this.dataView.setUint32(i, newView.getUint32(i));
-        }
+        // Replace the data from the old data array with the data in the array
+        const oldArray = new Uint8Array(this.dataMem);
+        oldArray.set(new Uint8Array(newData));
+
         this.freeStart = newOffset;
     }
 

--- a/src/map/__tests__/ShareableMap.spec.ts
+++ b/src/map/__tests__/ShareableMap.spec.ts
@@ -1,4 +1,4 @@
-import ShareableMap from "../ShareableMap";
+import {ShareableMap} from "../ShareableMap";
 
 describe("ShareableMap", () => {
     // How many key, value pairs will be generated? Retrieve them again later to check whether the corresponding values

--- a/src/map/__tests__/ShareableMap.spec.ts
+++ b/src/map/__tests__/ShareableMap.spec.ts
@@ -120,6 +120,66 @@ describe("ShareableMap", () => {
         expect(typeof map.get("k1")).toEqual("number");
     });
 
+    it("should clear all entries from the map", () => {
+        const map = new ShareableMap<string, string>();
+        map.set("key1", "value1");
+        map.set("key2", "value2");
+
+        map.clear();
+
+        expect(map.size).toBe(0);
+        expect(map.get("key1")).toBeUndefined();
+        expect(map.get("key2")).toBeUndefined();
+    });
+
+    it("should delete specific entries from the map", () => {
+        const map = new ShareableMap<string, string>();
+        map.set("key1", "value1");
+        map.set("key2", "value2");
+
+        expect(map.delete("key1")).toBeTruthy();
+        expect(map.delete("nonexistent")).toBeFalsy();
+
+        expect(map.size).toBe(1);
+        expect(map.get("key1")).toBeUndefined();
+        expect(map.get("key2")).toBe("value2");
+    });
+
+    it("should iterate over all entries using forEach", () => {
+        const map = new ShareableMap<string, number>();
+        const entries: [string, number][] = [
+            ["a", 1],
+            ["b", 2],
+            ["c", 3]
+        ];
+
+        entries.forEach(([key, value]) => map.set(key, value));
+
+        const result: [string, number][] = [];
+        map.forEach((value, key) => {
+            result.push([key, value]);
+        });
+
+        expect(result.toSorted()).toEqual(entries.toSorted());
+    });
+
+    it("should handle forEach on empty map", () => {
+        const map = new ShareableMap<string, number>();
+        let iterationCount = 0;
+
+        map.forEach(() => {
+            iterationCount++;
+        });
+
+        expect(iterationCount).toBe(0);
+    });
+
+    it("should return correct size for empty map", () => {
+        const map = new ShareableMap<string, string>();
+        expect(map.size).toBe(0);
+    });
+
+
     // it("should work with keys that are objects containing functions", () => {
     //     const map = new ShareableMap<{ firstName: string, lastName: string, testFunction: () => string }, string>();
     //

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -1,4 +1,4 @@
-import ShareableMap from "./ShareableMap";
+import {ShareableMap} from "./ShareableMap";
 import ShareableMapOptions from "./ShareableMapOptions";
 import {TransferableState} from "./TransferableState";
 

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -1,7 +1,5 @@
 import {ShareableMap} from "./ShareableMap";
 import ShareableMapOptions from "./ShareableMapOptions";
-import {TransferableState} from "./TransferableState";
-
 
 export { ShareableMap };
-export type { ShareableMapOptions, TransferableState };
+export type { ShareableMapOptions };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,13 @@ export default defineConfig({
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
   },
+  // Add server configuration for SharedArrayBuffer support
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp'
+    },
+    // Configure the server to open the benchmark HTML file
+    open: '/benchmark/index.html'
+  }
 });


### PR DESCRIPTION
This PR implements a new data structures, `ShareableArray`, similar to the `ShareableMap` that offers an Array-like interface, backed by SharedArrayBuffers.

A few important changes have also been made in this PR, making the binary representation of the datastructures incompatible with the previous version of this library:

* A new `dataType` key has been added to the `TransferableState`, allowing the state to differentiate between the two data structures.
* `ShareableMap` no longer implements the JavaScript `Map` interface to clearly indicate that it is not a 100% drop-in replacement (because of some limitations posed by the JavaScript programming language itself).
* The automatic fallback to a normal `ArrayBuffer` (in case `SharedArrayBuffer` is not available) has been removed. This is done because a lot of the other operations of the map also stop working if the underlying data buffer is not shared between workers.